### PR TITLE
Add group UI wrapper

### DIFF
--- a/libs/ide_services/__init__.py
+++ b/libs/ide_services/__init__.py
@@ -1,3 +1,3 @@
-from .services import get_lsp_brige_port
+from .services import get_lsp_brige_port, install_python_env, update_slash_commands, open_folder
 
-__all__ = ["get_lsp_brige_port"]
+__all__ = ["get_lsp_brige_port", "install_python_env", "update_slash_commands", "open_folder"]

--- a/libs/ide_services/services.py
+++ b/libs/ide_services/services.py
@@ -1,6 +1,5 @@
 import requests
 import os
-import json
 from functools import wraps
 
 BASE_SERVER_URL = os.environ.get("DEVCHAT_IDE_SERVICE_URL", "http://localhost:3000")
@@ -33,13 +32,16 @@ def rpc_call(f):
 def get_lsp_brige_port():
     pass
 
+
 @rpc_call
 def install_python_env(command_name: str, requirements_file: str) -> str:
     pass
 
+
 @rpc_call
 def update_slash_commands():
     pass
+
 
 @rpc_call
 def open_folder(folder: str):

--- a/libs/ide_services/services.py
+++ b/libs/ide_services/services.py
@@ -1,5 +1,6 @@
 import requests
 import os
+import json
 from functools import wraps
 
 BASE_SERVER_URL = os.environ.get("DEVCHAT_IDE_SERVICE_URL", "http://localhost:3000")
@@ -30,4 +31,16 @@ def rpc_call(f):
 
 @rpc_call
 def get_lsp_brige_port():
+    pass
+
+@rpc_call
+def install_python_env(command_name: str, requirements_file: str) -> str:
+    pass
+
+@rpc_call
+def update_slash_commands():
+    pass
+
+@rpc_call
+def open_folder(folder: str):
     pass

--- a/libs/ui_utils/__init__.py
+++ b/libs/ui_utils/__init__.py
@@ -1,7 +1,8 @@
 from .iobase import parse_response_from_ui, pipe_interaction, pipe_interaction_mock
-from .multi_selections import ui_checkbox_select, CheckboxOption
-from .single_select import ui_radio_select, RadioOption
-from .text_edit import ui_text_edit
+from .multi_selections import ui_checkbox_select, CheckboxOption, make_checkbox_control
+from .single_select import ui_radio_select, RadioOption, make_radio_control
+from .text_edit import ui_text_edit, make_editor_control
+from .group import ui_group
 
 
 __all__ = [
@@ -13,4 +14,8 @@ __all__ = [
     "ui_text_edit",
     "CheckboxOption",
     "RadioOption",
+    "make_checkbox_control",
+    "make_radio_control",
+    "make_editor_control",
+    "ui_group"
 ]

--- a/libs/ui_utils/__init__.py
+++ b/libs/ui_utils/__init__.py
@@ -17,5 +17,5 @@ __all__ = [
     "make_checkbox_control",
     "make_radio_control",
     "make_editor_control",
-    "ui_group"
+    "ui_group",
 ]

--- a/libs/ui_utils/group.py
+++ b/libs/ui_utils/group.py
@@ -14,18 +14,21 @@ def ui_group(ui_message: List[Tuple]) -> Tuple:
             ("checkbox", "checkbox ui message", ["id1", "id2"]),
             ("radio", "radio ui message", ["id1", "id2"]),
         ]
+        
+    items in ui_message are created by functions like:make_checkbox_control
     """
     ui_message = "\n".join([m[1] for m in ui_message])
     response = pipe_interaction(ui_message)
-    return tuple(
-        [
-            editor_answer(response, m[2])
-            if m[0] == "editor"
-            else checkbox_answer(response, m[2])
-            if m[0] == "checkbox"
-            else radio_answer(response, m[2])
-            if m[0] == "radio"
-            else None
-            for m in ui_message
-        ]
-    )
+
+    results = []
+    for m in ui_message:
+        if m[0] == "editor":
+            result = editor_answer(response, m[2])
+        elif m[0] == "checkbox":
+            result = checkbox_answer(response, m[2])
+        elif m[0] == "radio":
+            result = radio_answer(response, m[2])
+        else:
+            result = None
+        results.append(result)
+    return tuple(results)

--- a/libs/ui_utils/group.py
+++ b/libs/ui_utils/group.py
@@ -14,7 +14,7 @@ def ui_group(ui_message: List[Tuple]) -> Tuple:
             ("checkbox", "checkbox ui message", ["id1", "id2"]),
             ("radio", "radio ui message", ["id1", "id2"]),
         ]
-        
+
     items in ui_message are created by functions like:make_checkbox_control
     """
     ui_message = "\n".join([m[1] for m in ui_message])

--- a/libs/ui_utils/group.py
+++ b/libs/ui_utils/group.py
@@ -17,8 +17,10 @@ def ui_group(ui_message: List[Tuple]) -> Tuple:
 
     items in ui_message are created by functions like:make_checkbox_control
     """
-    ui_message = "\n".join([m[1] for m in ui_message])
-    response = pipe_interaction(ui_message)
+    ui_message_str = "\n".join([m[1] for m in ui_message])
+
+    ui_message_str = f"""```chatmark type=form\n{ui_message_str}\n```\n"""
+    response = pipe_interaction(ui_message_str)
 
     results = []
     for m in ui_message:

--- a/libs/ui_utils/group.py
+++ b/libs/ui_utils/group.py
@@ -1,0 +1,28 @@
+from typing import List, Tuple
+
+from .iobase import pipe_interaction
+from .multi_selections import checkbox_answer
+from .single_select import radio_answer
+from .text_edit import editor_answer
+
+
+def ui_group(ui_message: List[Tuple]) -> Tuple:
+    """
+    ui_message: List[Tuple]
+        [
+            ("editor", "editor ui message", "editor_id"),
+            ("checkbox", "checkbox ui message", ["id1", "id2"]),
+            ("radio", "radio ui message", ["id1", "id2"]),
+        ]
+    """
+    ui_message = "\n".join([m[1] for m in ui_message])
+    with open('tmp.txt', 'w+', encoding="utf8") as file:
+        file.write(ui_message)
+    response = pipe_interaction(ui_message)
+    return tuple([
+        editor_answer(response, m[2]) if m[0] == "editor" else
+        checkbox_answer(response, m[2]) if m[0] == "checkbox" else
+        radio_answer(response, m[2]) if m[0] == "radio" else
+        None
+        for m in ui_message
+    ])

--- a/libs/ui_utils/group.py
+++ b/libs/ui_utils/group.py
@@ -16,13 +16,16 @@ def ui_group(ui_message: List[Tuple]) -> Tuple:
         ]
     """
     ui_message = "\n".join([m[1] for m in ui_message])
-    with open('tmp.txt', 'w+', encoding="utf8") as file:
-        file.write(ui_message)
     response = pipe_interaction(ui_message)
-    return tuple([
-        editor_answer(response, m[2]) if m[0] == "editor" else
-        checkbox_answer(response, m[2]) if m[0] == "checkbox" else
-        radio_answer(response, m[2]) if m[0] == "radio" else
-        None
-        for m in ui_message
-    ])
+    return tuple(
+        [
+            editor_answer(response, m[2])
+            if m[0] == "editor"
+            else checkbox_answer(response, m[2])
+            if m[0] == "checkbox"
+            else radio_answer(response, m[2])
+            if m[0] == "radio"
+            else None
+            for m in ui_message
+        ]
+    )

--- a/libs/ui_utils/iobase.py
+++ b/libs/ui_utils/iobase.py
@@ -52,6 +52,7 @@ def pipe_interaction(output: str):
     while True:
         try:
             line = input()
+            print("--> input:", line)
             if line.strip().startswith("```yaml"):
                 lines = []
             elif line.strip() == "```":

--- a/libs/ui_utils/iobase.py
+++ b/libs/ui_utils/iobase.py
@@ -52,7 +52,6 @@ def pipe_interaction(output: str):
     while True:
         try:
             line = input()
-            print("--> input:", line)
             if line.strip().startswith("```yaml"):
                 lines = []
             elif line.strip() == "```":

--- a/libs/ui_utils/multi_selections.py
+++ b/libs/ui_utils/multi_selections.py
@@ -12,16 +12,7 @@ class CheckboxOption:
         self._checked = checked
 
 
-def ui_checkbox_select(title: str, options: List[CheckboxOption]) -> List[str]:
-    """
-    send text to UI as:
-    ```chatmark
-    Which files would you like to commit? I've suggested a few.
-    > [x](file1) devchat/engine/prompter.py
-    > [x](file2) devchat/prompt.py
-    > [](file3) tests/test_cli_prompt.py
-    ```
-    """
+def make_checkbox_control(title: str, options: List[CheckboxOption]) -> (str, str, List[str]):
     _NT = "\n"
     groups = list({option._group: 1 for option in options if option._group}.keys())
 
@@ -35,18 +26,30 @@ def ui_checkbox_select(title: str, options: List[CheckboxOption]) -> List[str]:
         return f"{group}:{_NT}{s}"
 
     ui_message = f"""
-```chatmark type=form
 {title}
 {_NT.join([_check_option_group_message(group) for group in groups])}
-```
     """
+    return ('checkbox', ui_message, [option._id for option in options])
+
+
+def checkbox_answer(response: dict, ids: List[str]) -> List[str]:
+    return [key for key, value in response.items() if value == "checked" and key in ids]
+
+
+def ui_checkbox_select(title: str, options: List[CheckboxOption]) -> List[str]:
+    """
+    send text to UI as:
+    ```chatmark
+    Which files would you like to commit? I've suggested a few.
+    > [x](file1) devchat/engine/prompter.py
+    > [x](file2) devchat/prompt.py
+    > [](file3) tests/test_cli_prompt.py
+    ```
+    """
+    _1, ui_message, ids = make_checkbox_control(title, options)
+    ui_message = f"""```chatmark type=form\n{ui_message}\n```\n"""
+
     # print(ui_message)
     # return [option._id for option in options]
     response = pipe_interaction(ui_message)
-
-    selected_options = [
-        key
-        for key, value in response.items()
-        if value == "checked" and key in [option._id for option in options]
-    ]
-    return selected_options
+    return checkbox_answer(response, ids)

--- a/libs/ui_utils/multi_selections.py
+++ b/libs/ui_utils/multi_selections.py
@@ -29,7 +29,7 @@ def make_checkbox_control(title: str, options: List[CheckboxOption]) -> (str, st
 {title}
 {_NT.join([_check_option_group_message(group) for group in groups])}
     """
-    return ('checkbox', ui_message, [option._id for option in options])
+    return ("checkbox", ui_message, [option._id for option in options])
 
 
 def checkbox_answer(response: dict, ids: List[str]) -> List[str]:

--- a/libs/ui_utils/single_select.py
+++ b/libs/ui_utils/single_select.py
@@ -19,7 +19,7 @@ def make_radio_control(title: str, options: List[RadioOption]) -> (str, str, Lis
 {title}
 {options_lines}
 """
-    return ('radio', ui_message, [option._id for option in options])
+    return ("radio", ui_message, [option._id for option in options])
 
 
 def radio_answer(response: dict, ids: List[str]) -> str | None:

--- a/libs/ui_utils/single_select.py
+++ b/libs/ui_utils/single_select.py
@@ -10,6 +10,23 @@ class RadioOption:
         self._text = text
 
 
+def make_radio_control(title: str, options: List[RadioOption]) -> (str, str, List[str]):
+    def _option_line(option):
+        return f"> - ({option._id}) {option._text}"
+
+    options_lines = "\n".join([_option_line(option) for option in options])
+    ui_message = f"""
+{title}
+{options_lines}
+"""
+    return ('radio', ui_message, [option._id for option in options])
+
+
+def radio_answer(response: dict, ids: List[str]) -> str | None:
+    selected_options = [key for key, value in response.items() if value == "checked" and key in ids]
+    return selected_options[0] if selected_options else None
+
+
 def ui_radio_select(title: str, options: List[RadioOption]) -> str | None:
     """
     ```chatmark type=form
@@ -19,23 +36,7 @@ def ui_radio_select(title: str, options: List[RadioOption]) -> str | None:
         > - (replace) Replace the current code.
         ```
     """
-
-    def _option_line(option):
-        return f"> - ({option._id}) {option._text}"
-
-    options_lines = "\n".join([_option_line(option) for option in options])
-    ui_message = f"""
-```chatmark type=form
-{title}
-{options_lines}
-```
-"""
-
+    _1, ui_message, ids = make_radio_control(title, options)
+    ui_message = f"""```chatmark type=form\n{ui_message}\n```\n"""
     response = pipe_interaction(ui_message)
-
-    selected_options = [
-        key
-        for key, value in response.items()
-        if value == "checked" and key in [option._id for option in options]
-    ]
-    return selected_options[0] if len(selected_options) > 0 else None
+    return radio_answer(response, ids)

--- a/libs/ui_utils/text_edit.py
+++ b/libs/ui_utils/text_edit.py
@@ -1,6 +1,29 @@
 from .iobase import pipe_interaction
 
 
+def make_editor_control(editor_id: str, title: str, text: str) -> (str, str, str):
+    text_lines = text.strip().split("\n")
+    if len(text_lines) > 0 and text_lines[0].strip().startswith("```"):
+        text_lines = text_lines[1:]
+    if len(text_lines) > 0 and text_lines[-1].strip() == "```":
+        text_lines = text_lines[:-1]
+    text = "\n".join(text_lines)
+    text = text.replace("\n", "\n> ")
+    ui_message = f"""
+{title}
+
+> | ({editor_id})
+> {text}
+"""
+    return ('editor', ui_message, editor_id)
+
+
+def editor_answer(response: dict, editor_id: str) -> str | None:
+    if editor_id in response:
+        return response[editor_id]
+    return None
+
+
 def ui_text_edit(title: str, text: str) -> str | None:
     """
     ```chatmark type=form
@@ -16,22 +39,8 @@ def ui_text_edit(title: str, text: str) -> str | None:
     > Refs: #123
     ```
     """
-    text_lines = text.strip().split("\n")
-    if len(text_lines) > 0 and text_lines[0].strip().startswith("```"):
-        text_lines = text_lines[1:]
-    if len(text_lines) > 0 and text_lines[-1].strip() == "```":
-        text_lines = text_lines[:-1]
-    text = "\n".join(text_lines)
-    text = text.replace("\n", "\n> ")
-    ui_message = f"""
-```chatmark type=form
-{title}
-
-> | (editor0)
-> {text}
-```
-"""
+    _1, ui_message, editor_id = make_editor_control("editor0", title, text)
+    ui_message = f"""```chatmark type=form\n{ui_message}\n```\n"""
     response = pipe_interaction(ui_message)
-    if "editor0" in response:
-        return response["editor0"]
-    return None
+    return editor_answer(response, editor_id)
+    

--- a/libs/ui_utils/text_edit.py
+++ b/libs/ui_utils/text_edit.py
@@ -15,7 +15,7 @@ def make_editor_control(editor_id: str, title: str, text: str) -> (str, str, str
 > | ({editor_id})
 > {text}
 """
-    return ('editor', ui_message, editor_id)
+    return ("editor", ui_message, editor_id)
 
 
 def editor_answer(response: dict, editor_id: str) -> str | None:
@@ -43,4 +43,3 @@ def ui_text_edit(title: str, text: str) -> str | None:
     ui_message = f"""```chatmark type=form\n{ui_message}\n```\n"""
     response = pipe_interaction(ui_message)
     return editor_answer(response, editor_id)
-    


### PR DESCRIPTION
Purpose: To support multiple control interactions in a single UI interaction.

Example usage:
```
import sys

sys.path.append(os.path.join(os.path.dirname(__file__), "..", "libs"))
sys.path.append(os.path.join(os.path.dirname(__file__), "..", "..", "libs"))

from ui_utils import CheckboxOption,  RadioOption, ui_group, make_checkbox_control, make_editor_control, make_radio_control  # noqa: E402 

def main():
    print("hello")
    checkbox_data = make_checkbox_control("checkbox ui message", [
        CheckboxOption("id1", "checkout 1", "checkbox"),
        CheckboxOption("id2", "checkout 2", "checkbox")
    ])
    radio_data = make_radio_control("radio ui message", [
        RadioOption("id3", "radio 1"),
        RadioOption("id4", "radio 2")
    ])
    editor_data = make_editor_control("id5", "editor ui message", "old message")
    (checkbox_result, radio_result, editor_result) = ui_group([checkbox_data, radio_data, editor_data])
    print(checkbox_result, radio_result, editor_result)


if __name__ == "__main__":
    main()

```

<img width="312" alt="截屏2023-12-18 21 00 44" src="https://github.com/devchat-ai/workflows/assets/95600496/f9a80f89-59a9-486b-9c85-5f3563caac01">
