### PR TITLE
fix: Add fetch depth to GitHub repository checkout

### DIFF
--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout GitHub repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Git
         run: |


### PR DESCRIPTION
- Add fetch-depth option to GitHub repository checkout step for improved syncing
- Update sync-to-gitlab.yml workflow file
- Ensure proper setup of Git for synchronization