### PR TITLE
Enhance form and widget button label functionality

### DIFF
--- a/commit/commit.py
+++ b/commit/commit.py
@@ -169,7 +169,7 @@ def get_marked_files(modified_files, staged_files):
         form_list.append("Unstaged:\n\n")
         form_list.append(unstaged_checkbox)
 
-    form = Form(form_list)
+    form = Form(form_list, submit_button_name="Continue")
 
     # Render the Form and get user input
     form.render()
@@ -283,7 +283,7 @@ def display_commit_message_and_commit(commit_message):
         None。
 
     """
-    text_editor = TextEditor(commit_message)
+    text_editor = TextEditor(commit_message, submit_button_name="Commit")
     text_editor.render()
 
     new_commit_message = text_editor.new_text

--- a/libs/chatmark/form.py
+++ b/libs/chatmark/form.py
@@ -14,8 +14,8 @@ class Form:
         self,
         components: List[Union[Widget, str]],
         title: Optional[str] = None,
-        submit_button_name="Submit",
-        cancel_button_name="Cancel",
+        submit_button_name: Optional[str] = None,
+        cancel_button_name: Optional[str] = None
     ):
         """
         components: components in the form, can be widgets (except Button) or strings
@@ -78,8 +78,12 @@ class Form:
 
         self._rendered = True
 
+        chatmark_header = "```chatmark"
+        chatmark_header += f" submit={self._submit}" if self._submit else ""
+        chatmark_header += f" cancel={self._cancel}" if self._cancel else ""
+
         lines = [
-            f"```chatmark submit={self._submit} cancel={self._cancel}",
+            chatmark_header,
             self._in_chatmark(),
             "```",
         ]

--- a/libs/chatmark/form.py
+++ b/libs/chatmark/form.py
@@ -14,6 +14,8 @@ class Form:
         self,
         components: List[Union[Widget, str]],
         title: Optional[str] = None,
+        submit_button_name = "Submit",
+        cancel_button_name = "Cancel"
     ):
         """
         components: components in the form, can be widgets (except Button) or strings
@@ -27,6 +29,8 @@ class Form:
         self._title = title
 
         self._rendered = False
+        self._submit = submit_button_name
+        self._cancel = cancel_button_name
 
     @property
     def components(self) -> List[Union[Widget, str]]:
@@ -75,7 +79,7 @@ class Form:
         self._rendered = True
 
         lines = [
-            "```chatmark type=form",
+            f"```chatmark submit={self._submit} cancel={self._cancel}",
             self._in_chatmark(),
             "```",
         ]

--- a/libs/chatmark/form.py
+++ b/libs/chatmark/form.py
@@ -14,8 +14,8 @@ class Form:
         self,
         components: List[Union[Widget, str]],
         title: Optional[str] = None,
-        submit_button_name = "Submit",
-        cancel_button_name = "Cancel"
+        submit_button_name="Submit",
+        cancel_button_name="Cancel",
     ):
         """
         components: components in the form, can be widgets (except Button) or strings

--- a/libs/chatmark/form.py
+++ b/libs/chatmark/form.py
@@ -15,7 +15,7 @@ class Form:
         components: List[Union[Widget, str]],
         title: Optional[str] = None,
         submit_button_name: Optional[str] = None,
-        cancel_button_name: Optional[str] = None
+        cancel_button_name: Optional[str] = None,
     ):
         """
         components: components in the form, can be widgets (except Button) or strings
@@ -37,6 +37,7 @@ class Form:
         """
         Return the components
         """
+
         return self._components
 
     def _in_chatmark(self) -> str:

--- a/libs/chatmark/widgets.py
+++ b/libs/chatmark/widgets.py
@@ -249,8 +249,7 @@ class Radio(Widget):
     def __init__(
         self,
         options: List[str],
-        # TODO: implement default_selected after the design is ready
-        # default_selected: Optional[int] = None,
+        default_selected: Optional[int] = None,
         title: Optional[str] = None,
         submit_button_name: str = "Submit",
         cancel_button_name: str = "Cancel"
@@ -269,7 +268,7 @@ class Radio(Widget):
         self._options = options
         self._title = title
 
-        self._selection: Optional[int] = None
+        self._selection: Optional[int] = default_selected
 
     @property
     def options(self) -> List[str]:
@@ -297,7 +296,10 @@ class Radio(Widget):
 
         for idx, option in enumerate(self._options):
             key = self.gen_id(self._id_prefix, idx)
-            lines.append(f"> - ({key}) {option}")
+            if self._selection is not None and self._selection == idx:
+                lines.append(f"> X ({key}) {option}")
+            else:
+                lines.append(f"> - ({key}) {option}")
 
         text = "\n".join(lines)
         return text

--- a/libs/chatmark/widgets.py
+++ b/libs/chatmark/widgets.py
@@ -9,7 +9,7 @@ class Widget(ABC):
     Abstract base class for widgets
     """
 
-    def __init__(self, submit: Optional[str] = None, cancel: str = "Cancel"):
+    def __init__(self, submit: Optional[str] = None, cancel: Optional[str] = None):
         self._rendered = False
         # Prefix for IDs/keys in the widget
         self._id_prefix = self.gen_id_prefix()
@@ -42,10 +42,9 @@ class Widget(ABC):
 
         self._rendered = True
 
-        if self._submit is None:
-            chatmark_header = "```chatmark"
-        else:
-            chatmark_header = f"```chatmark submit={self._submit} cancel={self._cancel}"
+        chatmark_header = "```chatmark"
+        chatmark_header += f" submit={self._submit}" if self._submit else ""
+        chatmark_header += f" cancel={self._cancel}" if self._cancel else ""
 
         lines = [
             chatmark_header,
@@ -261,9 +260,8 @@ class Radio(Widget):
         default_selected: index of the option to be selected by default, default to None
         title: title of the widget
         """
-        # TODO: implement default_selected after the design is ready
-        # if default_selected is not None:
-        #     assert 0 <= default_selected < len(options)
+        if default_selected is not None:
+            assert 0 <= default_selected < len(options)
 
         super().__init__(submit_button_name, cancel_button_name)
 
@@ -299,7 +297,7 @@ class Radio(Widget):
         for idx, option in enumerate(self._options):
             key = self.gen_id(self._id_prefix, idx)
             if self._selection is not None and self._selection == idx:
-                lines.append(f"> X ({key}) {option}")
+                lines.append(f"> x ({key}) {option}")
             else:
                 lines.append(f"> - ({key}) {option}")
 

--- a/libs/chatmark/widgets.py
+++ b/libs/chatmark/widgets.py
@@ -9,10 +9,12 @@ class Widget(ABC):
     Abstract base class for widgets
     """
 
-    def __init__(self):
+    def __init__(self, submit: Optional[str] = None, cancel: str = "Cancel"):
         self._rendered = False
         # Prefix for IDs/keys in the widget
         self._id_prefix = self.gen_id_prefix()
+        self._submit = submit
+        self._cancel = cancel
 
     @abstractmethod
     def _in_chatmark(self) -> str:
@@ -39,9 +41,14 @@ class Widget(ABC):
             raise RuntimeError("Widget can only be rendered once")
 
         self._rendered = True
+        
+        if self._submit is None:
+            chatmark_header = "```chatmark"
+        else:
+            chatmark_header = f"```chatmark submit={self._submit} cancel={self._cancel}"
 
         lines = [
-            "```chatmark",
+            chatmark_header,
             self._in_chatmark(),
             "```",
         ]
@@ -89,13 +96,15 @@ class Checkbox(Widget):
         options: List[str],
         check_states: Optional[List[bool]] = None,
         title: Optional[str] = None,
+        submit_button_name: str = "Submit",
+        cancel_button_name: str = "Cancel"
     ):
         """
         options: options to be selected
         check_states: initial check states of options, default to all False
         title: title of the widget
         """
-        super().__init__()
+        super().__init__(submit_button_name, cancel_button_name)
 
         if check_states is not None:
             assert len(options) == len(check_states)
@@ -183,8 +192,12 @@ class TextEditor(Widget):
     ```
     """
 
-    def __init__(self, text: str, title: Optional[str] = None):
-        super().__init__()
+    def __init__(self,
+                 text: str,
+                 title: Optional[str] = None,
+                 submit_button_name: str = "Submit",
+                 cancel_button_name: str = "Cancel"):
+        super().__init__(submit_button_name, cancel_button_name)
 
         self._title = title
         self._text = text
@@ -239,6 +252,8 @@ class Radio(Widget):
         # TODO: implement default_selected after the design is ready
         # default_selected: Optional[int] = None,
         title: Optional[str] = None,
+        submit_button_name: str = "Submit",
+        cancel_button_name: str = "Cancel"
     ) -> None:
         """
         options: options to be selected
@@ -249,7 +264,7 @@ class Radio(Widget):
         # if default_selected is not None:
         #     assert 0 <= default_selected < len(options)
 
-        super().__init__()
+        super().__init__(submit_button_name, cancel_button_name)
 
         self._options = options
         self._title = title

--- a/libs/chatmark/widgets.py
+++ b/libs/chatmark/widgets.py
@@ -41,7 +41,7 @@ class Widget(ABC):
             raise RuntimeError("Widget can only be rendered once")
 
         self._rendered = True
-        
+
         if self._submit is None:
             chatmark_header = "```chatmark"
         else:
@@ -97,7 +97,7 @@ class Checkbox(Widget):
         check_states: Optional[List[bool]] = None,
         title: Optional[str] = None,
         submit_button_name: str = "Submit",
-        cancel_button_name: str = "Cancel"
+        cancel_button_name: str = "Cancel",
     ):
         """
         options: options to be selected
@@ -192,11 +192,13 @@ class TextEditor(Widget):
     ```
     """
 
-    def __init__(self,
-                 text: str,
-                 title: Optional[str] = None,
-                 submit_button_name: str = "Submit",
-                 cancel_button_name: str = "Cancel"):
+    def __init__(
+        self,
+        text: str,
+        title: Optional[str] = None,
+        submit_button_name: str = "Submit",
+        cancel_button_name: str = "Cancel",
+    ):
         super().__init__(submit_button_name, cancel_button_name)
 
         self._title = title
@@ -252,7 +254,7 @@ class Radio(Widget):
         default_selected: Optional[int] = None,
         title: Optional[str] = None,
         submit_button_name: str = "Submit",
-        cancel_button_name: str = "Cancel"
+        cancel_button_name: str = "Cancel",
     ) -> None:
         """
         options: options to be selected


### PR DESCRIPTION
This pull request introduces two key features to enhance the user interface components:

- A `default_selected` parameter has been added to the Radio widget, allowing a default option to be specified and visually marked when the widget is rendered.
- Customizable button labels have been implemented, which enable different submit and cancel button names for the Form and TextEditor classes. Additionally, the chatmark header in the Widget class has been updated to reflect these custom labels. This change also affects the initialization of Checkbox and Radio classes.

These updates aim to provide a more flexible and user-friendly experience with our UI components.

As there was no specific issue linked to these changes, there is no issue to close with this pull request.