### PR TITLE
Fix staged file deletion flag display in commit workflow

### DIFF
--- a/commit/commit.py
+++ b/commit/commit.py
@@ -158,7 +158,9 @@ def get_marked_files(modified_files, staged_files):
     staged_checkbox = Checkbox(staged_files_show, [True] * len(staged_files_show))
 
     unstaged_files = [file for file in modified_files if file[1].strip() != ""]
-    unstaged_files_show = [f'{file[1] if file[1]!="?" else "U"} {file[0]}' for file in unstaged_files]
+    unstaged_files_show = [
+        f'{file[1] if file[1]!="?" else "U"} {file[0]}' for file in unstaged_files
+    ]
     unstaged_checkbox = Checkbox(unstaged_files_show, [False] * len(unstaged_files_show))
 
     # Create a Form with both Checkbox instances
@@ -197,7 +199,9 @@ def rebuild_stage_list(staged_select_files, unstaged_select_files):
         None
     """
     # 获取当前所有staged文件
-    current_staged_files = subprocess.check_output(["git", "diff", "--name-only", "--cached"], text=True).splitlines()
+    current_staged_files = subprocess.check_output(
+        ["git", "diff", "--name-only", "--cached"], text=True
+    ).splitlines()
 
     # 添加unstaged_select_files中的文件到staged
     for file in unstaged_select_files:
@@ -207,7 +211,7 @@ def rebuild_stage_list(staged_select_files, unstaged_select_files):
     user_selected_files = staged_select_files + unstaged_select_files
     files_to_unstage = [file for file in current_staged_files if file not in user_selected_files]
     for file in files_to_unstage:
-        subprocess.check_output(["git", "reset", file])    
+        subprocess.check_output(["git", "reset", file])
 
 
 def get_diff():


### PR DESCRIPTION
This PR adds a visual indicator for the modification status of each staged file, particularly to show a deletion flag (D) when files are marked for deletion, in order to align with common Git conventions as seen in VSCode Source Control.

- Added letters to represent the modification statuses of files
- Updated the workflow to correctly display file deletion flags in 'Staged' section
- Resolved the issue where deletion or modification status was not correctly shown for staged files

This change should make the modification status for each file more transparent and intuitive for users during the staging phase of the commit process.

Closes devchat-ai/devchat#197

staged flags:
M: modify
A: new Add file
D: delete file
unstaged flags:
M: modify
U: new file
D: delete file
looks like:
<img width="411" alt="截屏2024-01-24 22 01 31" src="https://github.com/devchat-ai/workflows/assets/95600496/7ff86def-03d0-41f9-adc4-d0101269bc15">


