### PR TITLE
Fix Windows ModuleNotFoundError on unit testing workflow

### DIFF
--- a/unit_tests/main.py
+++ b/unit_tests/main.py
@@ -3,6 +3,10 @@ import sys
 from typing import List, Tuple
 
 import click
+
+sys.path.append(os.path.dirname(__file__))
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "libs"))
+
 from find_reference_tests import find_reference_tests
 from i18n import TUILanguage, get_translation
 from model import (
@@ -13,8 +17,6 @@ from model import (
 from propose_test import propose_test
 from tools.file_util import retrieve_file_content
 from write_tests import write_and_print_tests
-
-sys.path.append(os.path.join(os.path.dirname(__file__), "..", "libs"))
 
 from chatmark import Checkbox, Form, Step, TextEditor  # noqa: E402
 from ide_services import ide_language  # noqa: E402

--- a/unit_tests/main.py
+++ b/unit_tests/main.py
@@ -7,8 +7,10 @@ import click
 sys.path.append(os.path.dirname(__file__))
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "libs"))
 
+from chatmark import Checkbox, Form, Step, TextEditor  # noqa: E402
 from find_reference_tests import find_reference_tests
 from i18n import TUILanguage, get_translation
+from ide_services import ide_language  # noqa: E402
 from model import (
     FuncToTest,
     TokenBudgetExceededException,
@@ -17,9 +19,6 @@ from model import (
 from propose_test import propose_test
 from tools.file_util import retrieve_file_content
 from write_tests import write_and_print_tests
-
-from chatmark import Checkbox, Form, Step, TextEditor  # noqa: E402
-from ide_services import ide_language  # noqa: E402
 
 
 class UnitTestsWorkflow:


### PR DESCRIPTION
This pull request addresses the issue where Windows users experienced a `ModuleNotFoundError` when running the unit testing workflow. The problem was due to an incorrect file path.

Changes:
- Adjusted the `sys.path.append` to ensure it occurs earlier in `main.py`
- Modified path handling to support Windows directory structure for unit tests

By moving the path append to an earlier phase and adjusting path access, it should now properly locate the needed modules on the Windows platform.

This resolves the issue reported in devchat-ai/devchat#226.