### PR TITLE
Fix token counting logic in relevant_file_finder.py and propose_test.py

### DIFF
--- a/unit_tests/assistants/directory_structure/relevant_file_finder.py
+++ b/unit_tests/assistants/directory_structure/relevant_file_finder.py
@@ -38,7 +38,7 @@ class RelevantFileFinder(DirectoryStructureBase):
             # Check if each page is within the token budget
             within_budget = True
             for p in pages:
-                tokens = len(self.encoding.encode(p))
+                tokens = len(self.encoding.encode(p, disallowed_special=()))
                 if tokens > self.dir_token_budget:
                     within_budget = False
                     break

--- a/unit_tests/propose_test.py
+++ b/unit_tests/propose_test.py
@@ -49,7 +49,7 @@ def _mk_user_msg(
     prioritized_msgs = [msg_1, msg_2]
 
     for msg in prioritized_msgs:
-        token_count = len(encoding.encode(msg))
+        token_count = len(encoding.encode(msg, disallowed_special=()))
         if token_count <= TOKEN_BUDGET:
             return msg
 

--- a/unit_tests/write_tests.py
+++ b/unit_tests/write_tests.py
@@ -67,7 +67,7 @@ def _mk_write_tests_msg(
     prioritized_msgs = [msg_1, msg_2, msg_3]
 
     for msg in prioritized_msgs:
-        tokens = len(encoding.encode(msg))
+        tokens = len(encoding.encode(msg, disallowed_special=()))
         if tokens <= TOKEN_BUDGET:
             return msg
 


### PR DESCRIPTION
This PR addresses issues within `relevant_file_finder.py` and `propose_test.py` where the token counting was incorrect. The changes ensure that tokens are counted accurately, improving the reliability of the related functionalities.

- A bug fix has been applied to the token counting mechanism in `relevant_file_finder.py`.
- Similar fixes have been made to `propose_test.py` to maintain consistency.