### PR TITLE
refactor: Remove redundant task query in test API upload command

### DIFF
--- a/community/test/api/upload/command.py
+++ b/community/test/api/upload/command.py
@@ -230,14 +230,6 @@ def main():
     api_path_id = get_path_op_id(api_path, method)
     with Step("开始查询测试脚本执行结果..."):
         while True:
-            res = session.get(
-                f"{SERVER_URL}/autotest/projects/{PROJECT_ID}/tasks",
-                params={"page": 1, "size": 1},
-            )
-            ret = res.json()
-            task = ret["tasks"][0]
-            task_id = task["id"]
-            wait_for_task_done(task_id)
             testcase = get_testcase(api_path_id)
             last_testcode_passed = testcase["last_testcode_passed"]
             if last_testcode_passed:


### PR DESCRIPTION
This PR refactors the test API upload command by:

- Removing unnecessary API call to fetch tasks
- Simplifying test execution flow by eliminating wait_for_task_done call
- Improving code efficiency in the test API upload command